### PR TITLE
fix: update faq link

### DIFF
--- a/.vitepress/theme/components/Route.vue
+++ b/.vitepress/theme/components/Route.vue
@@ -4,7 +4,7 @@
       <Badge v-if="!test" type="warning">🟡 Missing Test</Badge>
       <Badge v-if="test?.code" type="danger" :title="test?.message">🔴 Failed Test</Badge>
       <Badge v-if="test && !test?.code" type="tip">🟢 Passed Test</Badge>
-      <a v-if="data.features?.antiCrawler" href="/faq" target="_blank">
+      <a v-if="data.features?.antiCrawler" href="/guide/faqs" target="_blank">
         <Badge type="danger">🚨 Strict Anti-crawling</Badge>
       </a>
       <Badge v-if="data.features?.supportBT" type="tip">🔄 Support BT</Badge>


### PR DESCRIPTION
The path to the FAQ page has been updated to https://docs.rsshub.app/guide/faqs.