### PR TITLE
fix: render md to html string correctly

### DIFF
--- a/.vitepress/theme/components/Route.vue
+++ b/.vitepress/theme/components/Route.vue
@@ -41,7 +41,7 @@
           <code>{{ item.replace(/:|\?|\+|\*/g, '') }}</code>,{{ ' ' }}
           <!-- TODO: Handle below translations based on last character in the item -->
           required - {{ ' ' }}
-          <span>{{ renderMarkdown(data.parameters?.[item.replace(/:|\?|\+|\*/g, '')] || '') }}</span>
+          <span v-html="renderMarkdown(data.parameters?.[item.replace(/:|\?|\+|\*/g, '')] || '')"/>
         </li>
       </ul>
     </div>
@@ -52,7 +52,7 @@
           <code>{{ item.name }}</code>,{{ ' ' }}
           {{ item.optional ? 'optional' : 'required' }}
           {{ ' - ' }}
-          <span>{{ renderMarkdown(item.description) }}</span>
+          <span v-html="renderMarkdown(item.description)"/>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
`MarkdownIt.renderInline` and `MarkdownIt.render` return HTML string, not vue component. So I pass the html string to the v-html to render it.

before and now: 
![image](https://github.com/RSSNext/rsshub-docs/assets/31075337/c6bebdde-7627-4151-b074-a61a6af6b8d4)
