### PR TITLE
fix: update Via HTML link

### DIFF
--- a/src/joinus/new-rss/start-code.md
+++ b/src/joinus/new-rss/start-code.md
@@ -145,7 +145,7 @@ The handler function will be passed a parameter ctx. By the end of the function,
 We have three common methods of data acquisition:
 
 1.  [Via API](#via-api)
-2.  [Via HTML](#via-html-web-page-using-got)
+2.  [Via HTML](#via-html)
 3.  [Using puppeteer](#using-puppeteer)
 
 Next, we will continue to use GitHub repository Issues as an example to introduce how to write these three common Route Handler functions.


### PR DESCRIPTION
Update the path for #via-html.
before: 
https://docs.rsshub.app/joinus/new-rss/start-code#via-html-web-page-using-got
after: 
https://docs.rsshub.app/joinus/new-rss/start-code#via-html