### PR TITLE
fix: responsive hero image size

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -43,7 +43,7 @@
  *   in custom container, badges, etc.
  * -------------------------------------------------------------------------- */
 
- :root {
+:root {
   --vp-c-default-1: var(--vp-c-gray-1);
   --vp-c-default-2: var(--vp-c-gray-2);
   --vp-c-default-3: var(--vp-c-gray-3);
@@ -106,10 +106,12 @@
   --vp-home-hero-image-filter: blur(44px);
 }
 
-.VPHomeHero .VPImage,
-.VPHomeHero .image-bg {
-  max-width: 280px;
-  max-height: 280px;
+@media (min-width: 960px) {
+  .VPHomeHero .VPImage,
+  .VPHomeHero .image-bg {
+    max-width: 280px;
+    max-height: 280px;
+  }
 }
 
 .VPHomeHero .image-container {


### PR DESCRIPTION
## What

The default responsive style is not working when using the following selector on the hero image:

```css
.VPHomeHero .VPImage,
.VPHomeHero .image-bg {
  max-width: 280px;
  max-height: 280px;
}
  ```
  
  ## Why

This causes the hero image to keep the same size when the viewport width shrinks:

![image](https://github.com/RSSNext/rsshub-docs/assets/30898105/854d278d-3bfa-4cc1-b0c0-9c862130e25c)

## How

Add a media query:

```css
@media (min-width: 960px) { // added
  .VPHomeHero .VPImage,
  .VPHomeHero .image-bg {
    max-width: 280px;
    max-height: 280px;
  }
}
```