### PR TITLE
fix: fix HelloGithub link

### DIFF
--- a/src/routes/programming.md
+++ b/src/routes/programming.md
@@ -375,14 +375,6 @@ GitHub provides some official RSS feeds:
   | -------- | -------- | ---------- |
   | tiobe    | netcraft | db-engines |
 
-### 榜单报告 <Site url="hellogithub.com" size="sm" />
-
-<Route namespace="hellogithub" :data='{"path":["/ranking/:type?","/report/:type?"],"example":"/hellogithub/ranking","name":"榜单报告","maintainers":["moke8","nczitzk"],"description":"| 编程语言 | 服务器   | 数据库     |\n  | -------- | -------- | ---------- |\n  | tiobe    | netcraft | db-engines |","location":"report.ts"}' :test='{"code":1,"message":"expected 503 to be 200 // Object.is equality"}' />
-
-| 编程语言 | 服务器   | 数据库     |
-  | -------- | -------- | ---------- |
-  | tiobe    | netcraft | db-engines |
-
 ### 文章 <Site url="hellogithub.com" size="sm" />
 
 <Route namespace="hellogithub" :data='{"path":["/article/:sort?/:id?"],"categories":["programming"],"example":"/hellogithub/article","parameters":{"sort":"排序方式，见下表，默认为 `hot`，即热门","id":"标签 id，可在对应标签页 URL 中找到，默认为全部标签"},"features":{"requireConfig":false,"requirePuppeteer":false,"antiCrawler":false,"supportBT":false,"supportPodcast":false,"supportScihub":false},"name":"文章","maintainers":["moke8","nczitzk"],"description":"| 热门 | 最近 |\n  | ---- | ---- |\n  | hot  | last |","location":"index.ts"}' :test='{"code":1,"message":"expected 503 to be 200 // Object.is equality"}' />
@@ -394,10 +386,6 @@ GitHub provides some official RSS feeds:
 ### 月刊 <Site url="hellogithub.com" size="sm" />
 
 <Route namespace="hellogithub" :data='{"path":["/month","/volume"],"example":"/hellogithub/volume","name":"月刊","maintainers":["moke8","nczitzk","CaoMeiYouRen"],"location":"volume.ts"}' :test='{"code":1,"message":"Test timed out in 10000ms.\nIf this is a long-running test, pass a timeout value as the last argument or configure it globally with \"testTimeout\"."}' />
-
-### 月刊 <Site url="hellogithub.com" size="sm" />
-
-<Route namespace="hellogithub" :data='{"path":["/month","/volume"],"example":"/hellogithub/volume","name":"月刊","maintainers":["moke8","nczitzk","CaoMeiYouRen"],"location":"volume.ts"}' :test='{"code":1,"message":"expected 503 to be 200 // Object.is equality"}' />
 
 ## Hex-Rays <Site url="hex-rays.com"/>
 


### PR DESCRIPTION
`HelloGithub` 中的`榜单报告`和`月刊`各有两份

<img width="229" alt="Screenshot 2024-06-28 at 10 27 49 AM" src="https://github.com/RSSNext/rsshub-docs/assets/63844776/92b03481-86c6-4afa-8c83-9ccbf63cc072">
