### PR TITLE
docs: update BILIBILI_COOKIE instructions in config

### DIFF
--- a/src/deploy/config.md
+++ b/src/deploy/config.md
@@ -199,7 +199,7 @@ See docs of the specified route and `lib/config.ts` for detailed information.
     1.  打开 [https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/dynamic_new?uid=0&type=8](https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/dynamic_new?uid=0&type=8)
     2.  打开控制台，切换到 Network 面板，刷新
     3.  点击 dynamic_new 请求，找到 Cookie
-    4.  视频和专栏，UP 主粉丝及关注只要求 `SESSDATA` 字段，动态需复制整段 Cookie
+    4.  视频和专栏，UP 主粉丝及关注只要求 `SESSDATA` 字段，动态需复制整段 Cookie（删掉 `bili_ticket` 和 `bili_ticket_expires` 字段来延长有效期）
 -   `BILIBILI_DM_IMG_LIST`: 用于获取UP主投稿系列的路由，获取方式：
     1.  打开 [任意UP主个人空间页](https://space.bilibili.com/1)
     2.  打开控制台，切换到 Network 面板，关闭缓存，刷新，鼠标在窗口内不断移动

--- a/src/zh/deploy/config.md
+++ b/src/zh/deploy/config.md
@@ -199,7 +199,7 @@ healthcheck:
     1.  打开 [https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/dynamic_new?uid=0&type=8](https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/dynamic_new?uid=0&type=8)
     2.  打开控制台，切换到 Network 面板，刷新
     3.  点击 dynamic_new 请求，找到 Cookie
-    4.  视频和专栏，UP 主粉丝及关注只要求 `SESSDATA` 字段，动态需复制整段 Cookie (删掉 `bili_ticket` 和 `bili_ticket_expires` 字段来延长有效期)
+    4.  视频和专栏，UP 主粉丝及关注只要求 `SESSDATA` 字段，动态需复制整段 Cookie（删掉 `bili_ticket` 和 `bili_ticket_expires` 字段来延长有效期）
 
 ### Bitbucket
 

--- a/src/zh/deploy/config.md
+++ b/src/zh/deploy/config.md
@@ -199,7 +199,7 @@ healthcheck:
     1.  打开 [https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/dynamic_new?uid=0&type=8](https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/dynamic_new?uid=0&type=8)
     2.  打开控制台，切换到 Network 面板，刷新
     3.  点击 dynamic_new 请求，找到 Cookie
-    4.  视频和专栏，UP 主粉丝及关注只要求 `SESSDATA` 字段，动态需复制整段 Cookie
+    4.  视频和专栏，UP 主粉丝及关注只要求 `SESSDATA` 字段，动态需复制整段 Cookie (删掉 `bili_ticket` 和 `bili_ticket_expires` 字段来延长有效期)
 
 ### Bitbucket
 


### PR DESCRIPTION
经测试，在去掉  `bili_ticket` 和 `bili_ticket_expires` 字段后，Bilibili 的 Cookie 有效期明显变长了，不再是五六天就过期，故对文档做相关更改。