### PR TITLE
docs(deploy): refresh Sealos deployment option

### DIFF
--- a/src/deploy/index.md
+++ b/src/deploy/index.md
@@ -587,11 +587,11 @@ For changing the deployment project id or version id, please refer to `Deploying
 
 You can access your `Google App Engine URL` to check the deployment status
 
-## Deploy to Sealos(use Redis as cache)
+## Deploy to Sealos
 
-Automatic updates are included.
+The Sealos template deploys RSSHub with Redis caching, Browserless, persistent Redis storage, and an HTTPS endpoint.
 
-[![Deploy to Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://template.cloud.sealos.io/deploy?templateName=rsshub)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/rsshub)
 
 ## Deploy to PikaPods
 

--- a/src/ecosystem.md
+++ b/src/ecosystem.md
@@ -42,7 +42,7 @@ Please refer to [deployment](/deploy/) for details.
 
 - [Heroku](https://heroku.com/deploy?template=https%3A%2F%2Fgithub.com%2FDIYgod%2FRSSHub)
 
-- [Sealos](https://template.cloud.sealos.io/deploy?templateName=rsshub)
+- [Sealos](https://sealos.io/products/app-store/rsshub)
 
 - [Vercel](https://vercel.com/import/project?template=https://github.com/DIYgod/RSSHub)
 

--- a/src/zh/deploy/index.md
+++ b/src/zh/deploy/index.md
@@ -587,9 +587,9 @@ gcloud app deploy
 
 ## 部署到 Sealos
 
-包含自动更新
+Sealos 模板会部署 RSSHub、Redis 缓存、Browserless、Redis 持久化存储和 HTTPS 访问地址。
 
-[![Deploy to Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://template.cloud.sealos.io/deploy?templateName=rsshub)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/rsshub)
 
 ## 部署到 PikaPods
 

--- a/src/zh/ecosystem.md
+++ b/src/zh/ecosystem.md
@@ -42,7 +42,7 @@
 
 - [Heroku](https://heroku.com/deploy?template=https%3A%2F%2Fgithub.com%2FDIYgod%2FRSSHub)
 
-- [Sealos](https://template.cloud.sealos.io/deploy?templateName=rsshub)
+- [Sealos](https://sealos.io/products/app-store/rsshub)
 
 - [Vercel](https://vercel.com/import/project?template=https://github.com/DIYgod/RSSHub)
 


### PR DESCRIPTION
> **Dependency:** The live-validated template update is tracked in https://github.com/labring-actions/templates/pull/731. This pull request remains a draft until that change is merged and the published template is verified.

## Summary

This PR refreshes the existing Sealos deployment option in the English and
Chinese RSSHub documentation.

It:

- replaces the deprecated `template.cloud.sealos.io` URL with the current
  Sealos App Store URL
- documents the template's Redis cache, Browserless service, persistent Redis
  storage, and HTTPS endpoint
- keeps the deployment and ecosystem pages synchronized across both languages

## Validation

- Sealos template: https://sealos.io/products/app-store/rsshub
- Template source: https://github.com/labring-actions/templates/tree/kb-0.9/template/rsshub
- RSSHub image: `diygod/rsshub:2026-07-23`
- Tested deployment: 2026-07-24
- Verified: `/healthz`, cached and uncached routes, Browserless Playwright
  navigation, and Redis integration
- Persistence: KubeBlocks Redis persistent storage
- Documentation build: `pnpm run docs:build`

## Maintenance

I can help maintain the Sealos deployment path and update the documentation when
the RSSHub template or runtime dependencies change.